### PR TITLE
feat: 사서 로테이션 기능 및 API 추가

### DIFF
--- a/src/controller/rotation.controller.js
+++ b/src/controller/rotation.controller.js
@@ -98,9 +98,7 @@ export async function setRotationAndGet(req, res) {
 
 export async function updateAttendInfo(req, res) {
   let year = new Date().getFullYear();
-  let month = (new Date().getMonth() + 1) % 12 + 1;
-  if (month === 1)
-    year += 1;
+  let month = (new Date().getMonth()) % 12 + 1;
   if (month < 10) {
     month = "0" + month;
   }

--- a/src/controller/rotation.controller.js
+++ b/src/controller/rotation.controller.js
@@ -1,10 +1,19 @@
 import * as rotationRepository from "../data/rotation.js";
+import * as rotationUtils from "../utils/rotation.together.js";
 
 export async function addParticipant(req, res) {
-  const participant = req.body;
+  let participant = req.body;
   try {
     const exists = await rotationRepository.checkDuplicate(participant);
     if (!exists.length) {
+      let year = new Date().getFullYear();
+      const month = new Date().getMonth();
+      const nextMonth = (month + 1) % 12 + 1;
+      if (nextMonth === 1)
+        year += 1;
+      participant["month"] = nextMonth;
+      participant["year"] = year;
+      console.log(participant);
       await rotationRepository.addParticipant(participant);
       return res.status(200).json({ message: "OK" });
     }
@@ -12,6 +21,107 @@ export async function addParticipant(req, res) {
       return res.status(500).json({ message: "중복되는 참석자입니다." });
   } catch (error) {
     console.log(error);
-    return res.status(500).json({ message: "참석자 입력 실패."});
+    return res.status(500).json({ message: "참석자 입력 실패." });
+  }
+}
+
+export async function setRotationAndGet(req, res) {
+  const monthArrayInfo = rotationUtils.initMonthArray();
+  let month = monthArrayInfo.nextMonth;
+  if (month < 10) {
+    month = "0" + month;
+  }
+  let year = monthArrayInfo.year;
+  try {
+    let participants = await rotationRepository.getParticipants({ month: month, year: year });
+    let allAttend = true;
+    for (let i = 0; i < participants.length; i++) {
+      if (participants[i].isSet === 0) {
+        allAttend = false;
+      }
+    }
+    if (allAttend === true) {
+      console.log("Up to date");
+    } else {
+      for (let i = 0; i < participants.length; i++) {
+        try {
+          await rotationRepository.initAttendInfo({ intraId: participants[i].intraId, month: month, year: year });
+        } catch (error) {
+          console.log(error);
+          return res.status(500).json({ message: "사서 로테이션 실패." });
+        }
+      }
+      const rotationResult = rotationUtils.checkAttend(rotationUtils.setRotation(participants, monthArrayInfo));
+      if (rotationResult.status === false) {
+        return res.status(500).json({ message: rotationResult.message });
+      }
+      for (let i = 0; i < rotationResult.monthArray.monthArray.length; i++) {
+        for (let j = 0; j < rotationResult.monthArray.monthArray[i].length; j++) {
+          for (let k = 0; k < rotationResult.monthArray.monthArray[i][j].arr.length; k++) {
+            if (rotationResult.monthArray.monthArray[i][j].arr[k] != "0") {
+              let day = rotationResult.monthArray.monthArray[i][j].day;
+              if (day < 10) {
+                day = "0" + day;
+              }
+              let attendDate = year + "-" + month + "-" + day + ", ";
+              let participantId = rotationResult.monthArray.monthArray[i][j].arr[k];
+              try {
+                await rotationRepository.setAttendDate({ attendDate: attendDate, intraId: participantId, month: month, year: year });
+              } catch (error) {
+                console.log(error);
+                return res.status(500).json({ message: "사서 로테이션 실패" });
+              }
+            }
+          }
+        }
+      }
+    }
+  } catch (error) {
+    console.log(error);
+    return res.status(500).json({ message: "사서 로테이션 실패" });
+  }
+  try {
+    let participants = await rotationRepository.getParticipants({ month: month, year: year });
+    let participantInfo = [];
+    for (let i = 0; i < participants.length; i++) {
+      let date = participants[i].attendDate.split(",").slice(0,-1);
+      let participantId = participants[i].intraId;
+      participantInfo.push({ date: date, intraId: participantId });
+    }
+    console.log(participantInfo);
+    return res.status(200).json(participantInfo);
+  } catch (error) {
+    console.log(error);
+    return res.status(500).json({ message: "사서 로테이션 실패 "});
+  }
+}
+
+export async function updateAttendInfo(req, res) {
+  let year = new Date().getFullYear();
+  let month = (new Date().getMonth() + 1) % 12 + 1;
+  if (month === 1)
+    year += 1;
+  if (month < 10) {
+    month = "0" + month;
+  }
+  let intraId = req.body.intraId;
+  let before = req.body.before;
+  let after = req.body.after;
+  try {
+    const participantInfo = await rotationRepository.getParticipantInfo({ intraId: intraId, month: month, year: year });
+    let attendDates = participantInfo[0].attendDate.split(",").slice(0,-1);
+    let newDates = [];
+    for (let i = 0; i < attendDates.length; i++) {
+      if (attendDates[i] === before) {
+        newDates.push(after);
+      } else {
+        newDates.push(attendDates[i]);
+      }
+    }
+    await rotationRepository.updateAttendDate({ attendDate: newDates.toString() + ", ", intraId: intraId, month: month, year: year});
+    return res.status(200).json({ message: "OK" });
+  } catch (error) {
+    console.log(error);
+    return res.status(500).json({ message: "일정 업데이트 실패" });
   }
 }

--- a/src/controller/together.controller.js
+++ b/src/controller/together.controller.js
@@ -1,6 +1,5 @@
 import * as togetherRepository from "../data/together.js";
 import * as userRepository from "../data/auth.js";
-import * as togetherUtils from "../utils/rotation.together.js";
 import { publishMessage } from "./slack.controller.js";
 import { config } from "../config.js";
 

--- a/src/data/rotation.js
+++ b/src/data/rotation.js
@@ -3,8 +3,8 @@ import { db } from "../db/database.js";
 export async function addParticipant(participant) {
   const { intraId, attendLimit, month, year } = participant;
   return db
-    .execute("INSERT INTO rotation (intraId, attendLimit, month, year) VALUES (?,?,?,?)",
-      [intraId, attendLimit, month, year],
+    .execute("INSERT INTO rotation (intraId, attendLimit, month, year, isSet) VALUES (?,?,?,?,?)",
+      [intraId, attendLimit, month, year,0],
     )
     .then((result) => result[0].insertId);
 }

--- a/src/data/rotation.js
+++ b/src/data/rotation.js
@@ -1,10 +1,10 @@
 import { db } from "../db/database.js";
 
 export async function addParticipant(participant) {
-  const { intraId, attendLimit } = participant;
+  const { intraId, attendLimit, month, year } = participant;
   return db
-    .execute("INSERT INTO rotation (intraId, attendLimit) VALUES (?,?)",
-      [intraId, attendLimit],
+    .execute("INSERT INTO rotation (intraId, attendLimit, month, year) VALUES (?,?,?,?)",
+      [intraId, attendLimit, month, year],
     )
     .then((result) => result[0].insertId);
 }
@@ -13,6 +13,46 @@ export async function checkDuplicate(participant) {
   return db
     .execute("SELECT intraId from rotation WHERE intraId=?",
       [participant.intraId],
+    )
+    .then((result) => result[0]);
+}
+
+export async function getParticipants(dateInfo) {
+  return db
+    .execute("SELECT id, intraId, attendLimit, attendDate, isSet from rotation WHERE (month=? AND year=?)",
+      [dateInfo.month, dateInfo.year],
+    )
+    .then((result) => result[0]);
+}
+
+export async function getParticipantInfo(participantInfo) {
+  return db
+    .execute("SELECT id, intraId, attendLimit, attendDate, isSet from rotation WHERE (intraId=? AND month=? AND year=?)",
+      [participantInfo.intraId, participantInfo.month, participantInfo.year],
+    )
+    .then((result) => result[0]);
+}
+
+export async function setAttendDate(attendInfo) {
+  return db
+    .execute("UPDATE rotation SET attendDate=CONCAT(IFNULL(attendDate, ''),?),isSet=? WHERE (intraId=? AND month=? AND year=?)",
+      [attendInfo.attendDate, 1, attendInfo.intraId, attendInfo.month, attendInfo.year],
+    )
+    .then((result) => result[0]);
+}
+
+export async function initAttendInfo(attendInfo) {
+  return db
+    .execute("UPDATE rotation SET attendDate='',isSet=? WHERE (intraId=? AND month=? and year=?)",
+      [0, attendInfo.intraId, attendInfo.month, attendInfo.year],
+    )
+    .then((result) => result[0]);
+}
+
+export async function updateAttendDate(attendInfo) {
+  return db
+    .execute("UPDATE rotation SET attendDate=? WHERE (intraId=? AND month=? and year=?)",
+      [attendInfo.attendDate, attendInfo.intraId, attendInfo.month, attendInfo.year],
     )
     .then((result) => result[0]);
 }

--- a/src/routes/rotation.routes.js
+++ b/src/routes/rotation.routes.js
@@ -9,7 +9,7 @@ const router = express.Router();
 router.post("/attend", isAuth, rotationController.addParticipant);
 
 // 사서 로테이션 진행 및 결과 반환
-router.get("/", rotationController.setRotationAndGet);
+router.get("/", rotationController.getRotationInfo);
 
 // 사서 일정 변경
 router.patch("/update/:intraId", isAuth, rotationController.updateAttendInfo);

--- a/src/routes/rotation.routes.js
+++ b/src/routes/rotation.routes.js
@@ -5,6 +5,13 @@ import { isAuth } from "../middleware/auth.js";
 
 const router = express.Router();
 
+// 로테이션 참석 사서 추가
 router.post("/attend", isAuth, rotationController.addParticipant);
+
+// 사서 로테이션 진행 및 결과 반환
+router.get("/", rotationController.setRotationAndGet);
+
+// 사서 일정 변경
+router.patch("/update/:intraId", isAuth, rotationController.updateAttendInfo);
 
 export default router;

--- a/src/utils/rotation.together.js
+++ b/src/utils/rotation.together.js
@@ -1,112 +1,210 @@
-import * as togetherRepository from "../data/together.js";
-import * as userRepository from "../data/user.js";
-
-// 반환 값:
-// monthArray : 다음 달의 주차 별 평일을 담은 이차원 배열.
-// 평일 당 두 명의 사서가 들어가기 때문에, 각 주차 당 10개의 요소가 들어간다.
-// ex) 첫 번쨰 주차는 평일이 5일이고, 마지막 주차는 평일이 3일인 경우
-// [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0], ... [0, 0, 0, 0, 0, 0]]
-// nextMonth : 다음 달이 몇월인지 나타낸다.
-function initMonthArray() {
-  let year = new Date().getFullYear();
-  const month = new Date().getMonth();
-  const nextMonth = ((month + 1) % 12) + 1;
-  if (nextMonth === 1) year += 1;
-  const monthDays = new Date(year, nextMonth, 0).getDate();
-  const tmpMonthArray = [];
-  let tmp = [];
-  for (let i = 1; i <= monthDays; i++) {
-    if (
-      new Date(year, nextMonth - 1, i).getDay() > 0 &&
-      new Date(year, nextMonth - 1, i).getDay() < 6
-    ) {
-      tmp.push(0);
-      tmp.push(0);
-      if (i === monthDays) tmpMonthArray.push(tmp);
-    } else {
-      tmpMonthArray.push(tmp);
-      tmp = [];
-    }
-  }
-  const result = tmpMonthArray.filter((arrlen) => arrlen.length > 0);
-  return { monthArray: result, nextMonth: nextMonth };
+function sortByArray(array) {
+  array.sort((a, b) => b.attendLimit.length - a.attendLimit.length);
 }
 
 function shuffle(array) {
   array.sort(() => Math.random() - 0.5);
 }
 
-// 반환 값:
-// monthArray : 주차 별 사서들이 담긴 이차원 배열.
-// participant : 이번 달 로테이션에 참여하는 사서의 정보.
-async function setAttendance(attendance, monthArray) {
+function isEmptyObj(object) {
+  return JSON.stringify(object) === "{}";
+}
+
+export function initMonthArray() {
+  let year = new Date().getFullYear();
+  const month = new Date().getMonth();
+  const nextMonth = (month + 1) % 12 + 1;
+  if (nextMonth === 1)
+    year += 1;
+  const daysOfMonth = new Date(year, nextMonth, 0).getDate();
+  const tmpMonthArray = [];
+  
+  let tmpWeek = [];
+
+  for (let i = 1; i <= daysOfMonth; i++) {
+    let tmpDayObject = {};
+    let tmp = [];
+    if (new Date(year, nextMonth - 1, i).getDay() > 0 &&
+      new Date(year, nextMonth - 1, i).getDay() < 6) {
+      let day = new Date(year, nextMonth - 1, i).getDate();
+      tmp.push(0);
+      tmp.push(0);
+      tmpDayObject = {day: day, arr: tmp};
+      if (i === daysOfMonth)
+        tmpMonthArray.push(tmpWeek);
+    }
+    else {
+      tmpMonthArray.push(tmpWeek);
+      tmpDayObject = {};
+      tmpWeek = [];
+    }
+    if (!isEmptyObj(tmpDayObject)) {
+      tmpWeek.push(tmpDayObject);
+    }
+  }
+  const result = tmpMonthArray.filter(arrlen => arrlen.length > 0);
+  return ({monthArray: result, nextMonth: nextMonth, year: year});
+}
+
+export function setRotation(attendance, monthArrayInfo) {
   let canDuplicate = false;
   if (attendance.length < 10) canDuplicate = true;
-  let participation = 1;
+  let participation = 0;
   let participants = [];
-  for (let idx = 0; idx < attendance.length; idx++) {
-    participants.push({
-      id: attendance[idx].id,
-      userId: attendance[idx].userId,
-      attend: 0,
-    });
+  for (let i = 0; i < attendance.length; i++) {
+    participants.push({id: attendance[i].id, intraId: attendance[i].intraId,
+      attendLimit: attendance[i].attendLimit, attend: 0});
   }
   shuffle(participants);
-  for (let i = 0; i < monthArray.length; i++) {
-    for (let j = 0; j < monthArray[i].length; j++) {
-      let participant = undefined;
+  sortByArray(participants);
+  let checkContinue = false;
+  let continueIndex = 0;
+  let isLooped = false;
+  let isLoopedAgain = false;
+  for (let i = 0; i < monthArrayInfo.monthArray.length; i++) {
+    for (let j = 0; j < monthArrayInfo.monthArray[i].length; j++) {
+      let participant1 = undefined;
+      let arrIndex = 0;
       for (let k = 0; k < participants.length; k++) {
+        if (checkContinue === true) {
+          k += continueIndex;
+          checkContinue = false;
+        }
+        // console.log("first :", participants[k].userId, participants[k].attend, k)
         if (participants[k].attend < participation) {
-          if (monthArray[i].indexOf(participants[k].userId) < 0) {
-            participant = participants[k];
-            participant.attend += 1;
-            break;
+          if (participants[k].attendLimit
+            .indexOf(monthArrayInfo.monthArray[i][j].day) == -1) {
+            if (monthArrayInfo.monthArray[i][j].arr
+              .indexOf(participants[k].intraId) == -1) {
+              participant1 = participants[k];
+              participant1.attend += 1;
+              break;
+            }
           }
         } else {
-          if (participants[k].attend === participation && canDuplicate) {
-            console.log("duplication occurs!");
-            participant = participants[k];
-            participant.attend += 1;
-            break;
+          if (canDuplicate && (participants[k].attend == participation)) {
+            //console.log("Duplication occours!")
+            if (participants[k].attendLimit
+              .indexOf(monthArrayInfo.monthArray[i][j].day) == -1) {
+              if (monthArrayInfo.monthArray[i][j].arr
+                .indexOf(participants[k].intraId) == -1) {
+                participant1 = participants[k];
+                participant1.attend += 1;
+                break;
+              }
+            }
           }
         }
       }
-      if (participant === undefined) {
+      if (participant1 === undefined) {
         participation += 1;
-        if (!canDuplicate) j -= 1;
+        if (j > 0) {
+          j -= 1;
+        } else {
+          j = -1;
+        }
+        if (isLooped === false) {
+          isLooped = true;
+        } else if (isLooped === true) {
+          isLooped = false;
+          j += 1;
+        }
+        continue;
       } else {
-        monthArray[i][j] = participant.userId;
-        // DB 내 Team은 본인이 근무하는 가장 마지막 주차가 됩니다.
-        // 칼럼 설정 상 주차를 여러 개 포함할 수가 없어서...
-        await togetherRepository.createTeam(i + 1, participant.id);
-        participant = undefined;
+        continueIndex = 0;
+        checkContinue = false;
+        isLooped = false;
+        monthArrayInfo.monthArray[i][j].arr[arrIndex++] = participant1.intraId;
       }
+      // console.log("first: ", monthArrayInfo.monthArray[i][j], participation, i, j)
+
+      // 한 번 더 반복
+      let participant2 = undefined;
+      for (let k = 0; k < participants.length; k++) {
+        // console.log("second :", participants[k].userId, participants[k].attend, k)
+        if (participants[k].attend < participation) {
+          if (participants[k].attendLimit
+            .indexOf(monthArrayInfo.monthArray[i][j].day) == -1) {
+            if (monthArrayInfo.monthArray[i][j].arr
+              .indexOf(participants[k].intraId) == -1) {
+              participant2 = participants[k];
+              participant2.attend += 1;
+              break;
+            }
+          }
+        } else {
+          if (canDuplicate && (participants[k].attend <= participation + 1)) {
+            //console.log("Duplication occours!")
+            if (participants[k].attendLimit
+              .indexOf(monthArrayInfo.monthArray[i][j].day) == -1) {
+              if (monthArrayInfo.monthArray[i][j].arr
+                .indexOf(participants[k].intraId) == -1) {
+                participant2 = participants[k];
+                participant2.attend += 1;
+                break;
+              }
+            }
+          }
+        }
+      }
+      if (participant2 === undefined) {
+        participation += 1;
+        if (j > 0) {
+          j -= 1;
+        } else {
+          j = -1;
+        }
+        if (participant1 && isLooped === false) {
+          if (isLoopedAgain === true) {
+            isLoopedAgain = false;
+            continue;
+          }
+          let index = participants.findIndex(obj => obj.intraId === participant1.intraId);
+          continueIndex = index;
+          checkContinue = true;
+          isLooped = true;
+          isLoopedAgain = true;
+          participant1.attend -= 1;
+          monthArrayInfo.monthArray[i][j + 1].arr[0] = 0;
+        } else if (isLooped === true) {
+          isLooped = false;
+          isLoopedAgain = false;
+          j += 1;
+        }
+        continue;
+      } else {
+        continueIndex = 0;
+        checkContinue = false;
+        isLooped = false;
+        monthArrayInfo.monthArray[i][j].arr[arrIndex++] = participant2.intraId;
+      }
+      // console.log("second: ", monthArrayInfo.monthArray[i][j], participation, i, j)
     }
-    shuffle(participants);
   }
-  return { monthArray: monthArray, participants: participants };
+  // for (let i = 0; i < monthArrayInfo.monthArray.length; i++) {
+  //   for (let j = 0; j < monthArrayInfo.monthArray[i].length; j++) {
+  //     console.log(monthArrayInfo.monthArray[i][j]);
+  //   }
+  // }
+  return ({monthArray: monthArrayInfo, participants: participants});
 }
 
-export async function rotationEvent(eventId) {
-  const attendance = await togetherRepository.findAttendByEventId(eventId);
-  const monthArrayInfo = initMonthArray();
-  const rotationInfo = await setAttendance(
-    attendance,
-    monthArrayInfo.monthArray,
-  );
-  return { rotation: rotationInfo, nextMonth: monthArrayInfo.nextMonth };
-}
-
-export async function getParticipantsInfo(week, weekday) {
-  let userArray = [];
-  let user = undefined;
-  for (let i = 0; i < weekday.length; i++) {
-    let userObject = {};
-    user = await userRepository.findUserById(weekday[i]);
-    userObject["intraId"] = user.intraId;
-    userObject["profile"] = user.profile;
-    userObject["teamId"] = week;
-    userArray.push(userObject);
+export function checkAttend(attendInfo) {
+  let loop = 1;
+  let flag = true;
+  while (loop) {
+    flag = true;
+    if (loop > 100) {
+      break;
+    }
+    for (let i = 0; i < attendInfo.participants.length; i++) {
+      if (attendInfo.participants[i].attend === 0) flag = false;
+    }
+    if (flag === true)
+      break;
   }
-  return userArray;
+  if (flag === false)
+    return ({status: flag, loop: loop, message: "적합한 매칭을 만들지 못했습니다."});
+  else
+    return ({status: flag, loop: loop, ...attendInfo});
 }

--- a/src/utils/rotation.together.js
+++ b/src/utils/rotation.together.js
@@ -202,6 +202,7 @@ export function checkAttend(attendInfo) {
     }
     if (flag === true)
       break;
+    loop++;
   }
   if (flag === false)
     return ({status: flag, loop: loop, message: "적합한 매칭을 만들지 못했습니다."});


### PR DESCRIPTION
사서 로테이션 기능 및 API를 추가하였습니다.

**전체 API 설명**

GET `/api/rotation` : **이번 달** 사서 로테이션 전체 결과를 가져옵니다.
POST `/api/rotation/attend` : **다음 달** 사서 로테이션에 참여함과 동시에, **다음 달** 사서 로테이션 배정 코드가 내부적으로 작동합니다.
  - 인자로 `{ intraId(text), attendLimit(array) }`을 JSON 형태로 받습니다.
  - 인자로 들어오는 intraId 유저가 다음 달 사서 로테이션에 참여하게 됩니다. `attendLimit`은 해당 사서가 다음 달에 참여하지 못하는 날짜를 담습니다.
PATCH `/api/rotation/update/:intraId` : 해당 사서의 이번 달 사서 참여 날짜를 변경합니다.
  - 인자로 `{ intraId(text), before(text), after(text) }`을 JSON 형태로 받습니다.
  - `before`에는 원래 사서 참여 일자, `after`에는 변경하고자 하는 사서 참여 일자를 담습니다.
  - `before`, `after`는 XXXX-XX-XX 형식으로 날짜를 설정해야 합니다.

사서 로테이션 기능이 잘 돌아가는지는 아래 링크에서 테스트할 수 있습니다. (혹시 엣지 케이스 발생 시 말씀해주세요!!!!)
- [https://playcode.io/1079050](https://playcode.io/1079050)

빠른 테스트를 위해 기능 동작만 서둘러 구현하다보니, 코드의 품질이 완전 구립니다... 나중에 열심히 리팩토링 해보겠습니다...
그리고 공휴일 제외 기능은 아직 추가하지 않았는데, 이후 빠른 시일 내에 공휴일 제외 기능도 추가하겠습니다!!