### PR TITLE
feat : event category 추가 및 참석 포인트 get api 추가

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,10 @@ import { stream } from "./config/winston.js";
 import rateLimit from "./middleware/rate-limiter.js";
 import expressBasicAuth from "express-basic-auth";
 import cron from "node-cron";
+import {
+  createWeeklyMeetingEvent,
+  matchWeeklyMeetingEvent,
+} from "./controller/together.controller.js";
 import { postRotationMessage } from "./controller/rotation.controller.js";
 
 // express configuration
@@ -60,9 +64,20 @@ if (process.env.BACKEND_LOCAL_HOST || process.env.BACKEND_TEST_HOST) {
   );
 }
 
+// 사서 로테이션 돌림
 cron.schedule("0 8 * * *", function () {
   const ret = postRotationMessage();
-  console.log(ret);
+  console.log("ret", ret);
+});
+
+// 주간 회의 자동 생성
+cron.schedule("0 12 * * 4", function () {
+  createWeeklyMeetingEvent();
+});
+
+// 주간 회의 자동 매칭
+cron.schedule("0 10 * * 3", function () {
+  matchWeeklyMeetingEvent();
 });
 
 //route

--- a/src/controller/together.controller.js
+++ b/src/controller/together.controller.js
@@ -207,3 +207,8 @@ export async function getEventInfo(req, res) {
   }
   res.status(200).json(eventList);
 }
+
+export async function getAttendingPoint(req, res) {
+  const pointList = await togetherRepository.getAttendingPoint();
+  res.status(200).json({ pointList });
+}

--- a/src/controller/together.controller.js
+++ b/src/controller/together.controller.js
@@ -210,5 +210,5 @@ export async function getEventInfo(req, res) {
 
 export async function getAttendingPoint(req, res) {
   const pointList = await togetherRepository.getAttendingPoint();
-  res.status(200).json({ pointList });
+  res.status(200).json(pointList);
 }

--- a/src/controller/together.controller.js
+++ b/src/controller/together.controller.js
@@ -174,7 +174,7 @@ export async function matching(req, res) {
 }
 
 export async function matchWeeklyMeetingEvent() {
-  const event = await togetherRepository.getMeetingEvent();
+  const event = await togetherRepository.getEventByCategory(1);
   if (event === undefined) return;
   const check = await togetherRepository.findAttendByEventId(event.id);
   // 참석자가 없는 경우

--- a/src/controller/together.controller.js
+++ b/src/controller/together.controller.js
@@ -5,7 +5,7 @@ import { config } from "../config.js";
 
 //이벤트 생성
 export async function createEvent(req, res) {
-  const { title, description } = req.body;
+  const { title, description, categoryId } = req.body;
   const user = await userRepository.findById(req.userId);
   console.log(user);
   const createdId = user.id;
@@ -13,6 +13,7 @@ export async function createEvent(req, res) {
     title,
     description,
     createdId,
+    categoryId,
   });
   let str = `:fire: 친바 공지 !! :fire:\n\n${title} 이벤트가 생성되었습니다. \nhttps://together42.github.io/frontend/\n서둘러 참석해주세요`;
   await publishMessage(config.slack.jip, str);

--- a/src/data/together.js
+++ b/src/data/together.js
@@ -8,6 +8,13 @@ export async function getEventList() {
     .then((result) => result[0]);
 }
 
+export async function getEventByCategory(categoryId) {
+  return db
+    .execute("SELECT * FROM event_info WHERE categoryId=?", [categoryId])
+    .then((result) => result[0][0])
+    .catch(() => undefined);
+}
+
 export async function findByEventId(id) {
   return (
     db
@@ -100,11 +107,4 @@ export async function createTeam(teamId, id) {
   return db
     .execute("UPDATE attendance_info SET teamId=? WHERE id=?", [teamId, id])
     .then(() => getByAttendId(id));
-}
-
-export async function getMeetingEvent() {
-  return db
-    .execute("SELECT * FROM event_info WHERE categoryId=1")
-    .then((result) => result[0][0])
-    .catch(() => undefined);
 }

--- a/src/data/together.js
+++ b/src/data/together.js
@@ -108,3 +108,16 @@ export async function createTeam(teamId, id) {
     .execute("UPDATE attendance_info SET teamId=? WHERE id=?", [teamId, id])
     .then(() => getByAttendId(id));
 }
+
+export async function getAttendingPoint() {
+  return db
+    .execute(
+      `SELECT at.userId, us.intraId, us.profile, ev.categoryId, COUNT(at.userId) as point
+      FROM attendance_info as at 
+      JOIN users as us ON at.userId=us.id 
+      JOIN event_info as ev ON at.eventId=ev.id
+      WHERE ev.isMatching=1
+      GROUP BY at.userId, ev.categoryId;`,
+    )
+    .then((result) => result[0]);
+}

--- a/src/data/together.js
+++ b/src/data/together.js
@@ -112,12 +112,16 @@ export async function createTeam(teamId, id) {
 export async function getAttendingPoint() {
   return db
     .execute(
-      `SELECT at.userId, us.intraId, us.profile, ev.categoryId, COUNT(at.userId) as point
-      FROM attendance_info as at 
+      `SELECT at.userId, us.intraId, us.profile, COUNT(at.userId) as totalPoint, 
+      COUNT(case when  ev.categoryId = 1 then 1 end) as meetingPoint,
+      COUNT(case when  ev.categoryId = 2 then 1 end) as eventPoint
+      FROM attendance_info  as at 
       JOIN users as us ON at.userId=us.id 
       JOIN event_info as ev ON at.eventId=ev.id
       WHERE ev.isMatching=1
-      GROUP BY at.userId, ev.categoryId;`,
+      GROUP BY at.userId
+      ORDER BY totalPoint DESC;
+      `,
     )
     .then((result) => result[0]);
 }

--- a/src/data/together.js
+++ b/src/data/together.js
@@ -3,7 +3,7 @@ import { db } from "../db/database.js";
 export async function getEventList() {
   return db
     .execute(
-      "SELECT ev.id, ev.title, ev.description, ev.createdId, us.intraId, ev.isMatching FROM event_info as ev JOIN users as us ON ev.createdId=us.id",
+      "SELECT ev.id, ev.title, ev.description, ev.createdId, us.intraId, ev.isMatching, ev.categoryId FROM event_info as ev JOIN users as us ON ev.createdId=us.id",
     )
     .then((result) => result[0]);
 }
@@ -31,11 +31,11 @@ export async function deleteEvent(id) {
 }
 
 export async function createEvent(event) {
-  const { title, description, createdId } = event;
+  const { title, description, createdId, categoryId } = event;
   return db
     .execute(
-      "INSERT INTO event_info (title, description, createdId) VALUES (?,?,?)",
-      [title, description, createdId],
+      "INSERT INTO event_info (title, description, createdId, categoryId) VALUES (?,?,?,?)",
+      [title, description, createdId, categoryId],
     )
     .then((result) => result[0].insertId);
 }

--- a/src/data/together.js
+++ b/src/data/together.js
@@ -71,7 +71,7 @@ export async function findAttendByEventId(eventId) {
     .then((result) => result[0]);
 }
 
-export async function chagneEvent(eventId) {
+export async function changeEvent(eventId) {
   return db.execute("UPDATE event_info SET isMatching=1 WHERE id=?", [eventId]);
 }
 
@@ -100,4 +100,11 @@ export async function createTeam(teamId, id) {
   return db
     .execute("UPDATE attendance_info SET teamId=? WHERE id=?", [teamId, id])
     .then(() => getByAttendId(id));
+}
+
+export async function getMeetingEvent() {
+  return db
+    .execute("SELECT * FROM event_info WHERE categoryId=1")
+    .then((result) => result[0][0])
+    .catch(() => undefined);
 }

--- a/src/routes/together.routes.js
+++ b/src/routes/together.routes.js
@@ -12,6 +12,7 @@ router.delete("/unregister/:id", isAuth, togetherController.unregister);
 router.post("/matching", isAuth, togetherController.matching);
 router.get("/matching", togetherController.getEventInfo);
 router.get("/matching/:id", togetherController.getTeam);
+router.get("/point", togetherController.getAttendingPoint);
 router.get("/:id", togetherController.getEvent);
 router.delete("/:id", isAuth, togetherController.deleteEvent);
 


### PR DESCRIPTION
이벤트를 분류해서 나누어두기 위해 event_info 테이블을 좀 손보았습니다. 아마 실배포 DB를 바꾸어야 할 듯합니다.
일단, 프론트 페이지에서는 아래와 같이 나옵니다.
<img width="842" alt="image" src="https://user-images.githubusercontent.com/79993356/224476786-df416272-b3c7-44df-90de-c965b04eb1ea.png">


참석 포인트는 아래와 같이 나옵니다.
<img width="848" alt="image" src="https://user-images.githubusercontent.com/79993356/224476794-f5d6d34a-74ae-4b27-accf-ecd981581233.png">

<img width="842" alt="image" src="https://user-images.githubusercontent.com/79993356/224476721-966abb57-70dc-43b7-99b8-314134e7a147.png">