### PR TITLE
fix: fix crontab message and matched time

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -67,8 +67,7 @@ if (process.env.BACKEND_LOCAL_HOST || process.env.BACKEND_TEST_HOST) {
 
 // 사서 로테이션 돌림
 cron.schedule("0 8 * * *", function () {
-  const ret = postRotationMessage();
-  console.log("ret", ret);
+  postRotationMessage();
 });
 
 // 주간 회의 자동 생성

--- a/src/controller/rotation.controller.js
+++ b/src/controller/rotation.controller.js
@@ -328,39 +328,29 @@ export async function deleteAttendInfo(req, res) {
 }
 
 export async function postRotationMessage() {
-  const getWeekNumber = (dateFrom = new Date()) => {
-    let currentDate = dateFrom.getDate();
-    let startOfMonth = new Date(dateFrom.setDate(1));
-    let weekDay = startOfMonth.getDay();
-    return Math.floor((weekDay - 1 + currentDate) / 7) + 1;
-  };
-  const today = new Date().getDay();
-
-  let year = new Date().getFullYear();
-  let month = (new Date().getMonth() % 12) + 1;
-  let todayNum = new Date().getDate();
-  const getLastDayOfMonth = new Date(year, month, 0).getDate();
-
+  const fourthWeekDays = getFourthWeekdaysOfMonth();
+  let fourthWeekStartDay = fourthWeekDays[0];
+  let fourthWeekFifthDay = fourthWeekDays[4];
+  let fourthWeekEndDay = fourthWeekDays[fourthWeekDays.length - 1];
+  let today = new Date().getDate();
   try {
-    if (
-      (getWeekNumber() == 4 && today == 1) ||
-      (getWeekNumber() == 4 && today == 5)
-    ) {
-      let str = `마감 ${
-        getLastDayOfMonth - todayNum
-      }일 전! 사서 로테이션 신청 기간입니다. 친바 홈페이지에서 사서 로테이션 신청을 해주세요!`;
+    if (today === fourthWeekStartDay || today == fourthWeekFifthDay) {
+      let str = `<!channel> 마감 ${
+        fourthWeekEndDay - today
+      }일 전! 사서 로테이션 신청 기간입니다. 친바 홈페이지에서 사서 로테이션 신청을 해주세요! <a href="https://together.42jip.net/">https://together.42jip.net/</a>`;
       await publishMessage(config.slack.jip, str);
-      return "CRON JOB SUCCESS";
-    }
-    if (todayNum == getLastDayOfMonth) {
-      let str =
-        "사서 로테이션이 완료되었습니다. 친바 홈페이지에서 확인해주세요!";
-      await publishMessage(config.slack.jip, str);
-      return "CRON JOB SUCCESS";
+    } else {
+      let year = new Date().getFullYear();
+      let month = (new Date().getMonth() % 12) + 1;
+      let lastDay = new Date(year, month, 0).getDate();
+      if (today === lastDay) {
+        let str =
+          `<!channel> 다음 달 사서 로테이션이 완료되었습니다. 친바 홈페이지에서 확인해주세요! <a href="https://together.42jip.net/">https://together.42jip.net/</a>`;
+        await publishMessage(config.slack.jip, str);
+      }
     }
   } catch (error) {
     console.log(error);
-    return "CRON JOB FAILED";
   }
 }
 


### PR DESCRIPTION
저번에 크론탭 메시지가 의도한 날짜에 제대로 표시되지 않는 것 같아, 날짜를 다시 수정했습니다. 그런데... 음... 제대로 잘 동작할지는 잘 모르겠어요...

크론탭으로 매일 8시마다 오늘 날짜를 체크해서, 만약 사서 신청 기간인 4주차인 경우, 4주차의 첫 번째 날과 5번째 날에 메시지를 보내도록 했습니다. 그리고 이 달의 가장 마지막 날에, 사서 신청이 완료되었다고 메시지를 보내도록 했습니다.