### PR TITLE
fix: fix query holiday

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,7 @@ import {
   matchWeeklyMeetingEvent,
 } from "./controller/together.controller.js";
 import { postRotationMessage } from "./controller/rotation.controller.js";
+import { storeHolidayInfo } from "./utils/rotation.calendar.js";
 
 // express configuration
 const app = express();
@@ -65,8 +66,20 @@ if (process.env.BACKEND_LOCAL_HOST || process.env.BACKEND_TEST_HOST) {
   );
 }
 
+// 매 달 첫 날, 다음 달에 휴일이 있는지 확인하여, DB에 저장.
+cron.schedule("0 0 1 * *", function() {
+  storeHolidayInfo()
+    .then(response => {
+      console.log(`Store holiday data status: ${response.status}`);
+    })
+    .catch(error => {
+      console.log('Error occurred while stroing holiday data:');
+      console.log(error);
+    });
+});
+
 // 매일 사서 로테이션 요일 확인 후 해당 요일에 메세지 전송
-cron.schedule("0 8 * * *", function () {
+cron.schedule("0 08 * * *", function () {
   postRotationMessage();
 });
 

--- a/src/data/rotation.js
+++ b/src/data/rotation.js
@@ -94,3 +94,37 @@ export async function updateAttendDate(attendInfo) {
     )
     .then((result) => result[0]);
 }
+
+export async function addHolidayInfo(holidayInfo) {
+  const { year, month, day, info } = holidayInfo;
+  try {
+    const [rows] = await db.execute(
+      "SELECT * FROM holiday_info WHERE year = ? AND month = ? AND day = ?", 
+      [year, month, day],
+    );
+    if (rows.length === 0) {
+      return db
+        .execute("INSERT INTO holiday_info (month, year, day, info) VALUES (?,?,?,?)",
+        [month, year, day, info],
+        )
+        .then((result) => result[0]);
+    } else {
+      console.log('Record already exists');
+    }
+  } catch (error) {
+    throw error;
+  }
+}
+
+export async function getHolidayByMonth(holidayInfo) {
+  const { year, month } = holidayInfo;
+  try {
+    return db
+      .execute("SELECT * FROM holiday_info WHERE year = ? AND month = ?", 
+      [year, month],
+      )
+      .then((result) => result[0]);
+  } catch (error) {
+    throw error;
+  }
+}

--- a/src/utils/rotation.calendar.js
+++ b/src/utils/rotation.calendar.js
@@ -1,6 +1,6 @@
+import { addHolidayInfo, getHolidayByMonth } from "../data/rotation.js";
 import request from "request";
 import { config } from "../config.js";
-
 
 export function getTodayDate() {
   const today = new Date();
@@ -28,35 +28,64 @@ export function getFourthWeekdaysOfMonth() {
   return (fourthWeekDays);
 }
 
-export async function getHolidayOfMonth() {
+export async function storeHolidayInfo() {
   const URL = 'http://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/getHoliDeInfo';
-  const solYear = new Date().getFullYear();
-  const month = new Date().getMonth() + 1;
+  let month = new Date().getMonth() + 2;
   const solMonth = month < 10 ? '0' + month : month;
+  let year = new Date().getFullYear();
+  const solYear = month === 1 ? year += 1 : year;
   const SERVICEKEY = config.openApi.holidayKey;
   const requestUrl = URL + '?' + 'solYear=' + solYear + '&' + 'solMonth=' + solMonth + '&' + 'ServiceKey=' + SERVICEKEY + '&' + '_type=json';
-  
-  return new Promise((resolve, reject) => {  
-    request(requestUrl, function (error, response, body) {
+
+  return new Promise((resolve, reject) => {
+    request(requestUrl, async function (error, response, body) {
       if (error) {
         reject ({ status: response.statusCode, message: "openApi query error" });
       }
       const returnData = JSON.parse(body);
       const items = returnData['response']['body']['items']['item'];
-      let holidayArray = [];
       if (Array.isArray(items)) {
         for (let i = 0; i < items.length; i++) {
+          let holidayArray = [];
           let item = items[i];
           if (item['locdate']) {
-            holidayArray.push(item['locdate']);
+            console.log(item['locdate'], typeof(item['locdate']));
+            const holidayInfo = {
+              year: item['locdate'].toString().substr(0, 4),
+              month: item['locdate'].toString().substr(4, 2),
+              day: item['locdate'].toString().substr(6, 2),
+              info: item['dateName']
+            };
+            holidayArray.push(holidayInfo);
+
+            await addHolidayInfo(holidayInfo)
+              .catch(error => reject({ status: 500, message: error }));
           }
         }
       } else if (typeof items === 'object') {
         if (items['locdate']) {
-          holidayArray.push(items['locdate']);
+          let holidayArray = [];
+          const holidayInfo = {
+            year: items['locdate'].toString().substr(0, 4),
+            month: items['locdate'].toString().substr(4, 2),
+            day: items['locdate'].toString().substr(6, 2),
+            info: items['dateName']
+          };
+          holidayArray.push(holidayInfo);
+
+          await addHolidayInfo(holidayInfo)
+            .catch(error => reject({ status: 500, message: error }));
         }
       }
-      resolve ({ status: response.statusCode, data: holidayArray });
+      resolve ({ status: response.statusCode });
     });
   });
+}
+
+export async function getHolidayOfMonth() {
+  let month = new Date().getMonth() + 2;
+  let year = month === 1 ? new Date().getFullYear() + 1 : new Date().getFullYear();
+  month = 11;
+  const holidayArray = await getHolidayByMonth({ year: year, month: month });
+  console.log(holidayArray);
 }

--- a/src/utils/rotation.together.js
+++ b/src/utils/rotation.together.js
@@ -14,10 +14,9 @@ function isEmptyObj(object) {
 }
 
 async function isNotHoliday(day) {
-  let response = await getHolidayOfMonth();
-  let holiday = response.data.map(dateString => dateString.slice(-2));
-  let checkDay = day < 10 ? '0' + day : day;
-  if (holiday.indexOf(checkDay.toString()) > 0) {
+  const response = await getHolidayOfMonth();
+  const holidayArray = response.map(item => parseInt(item.day));
+  if (holidayArray.indexOf(Number(day)) >= 0) {
     return false;
   }
   return true;
@@ -40,7 +39,7 @@ export async function initMonthArray() {
     if (new Date(year, nextMonth - 1, i).getDay() > 0 &&
       new Date(year, nextMonth - 1, i).getDay() < 6) {
       let day = new Date(year, nextMonth - 1, i).getDate();
-      if (await isNotHoliday(day)) {
+      if (isNotHoliday(day)) {
         tmp.push(0);
         tmp.push(0);
         tmpDayObject = {day: day, arr: tmp};


### PR DESCRIPTION
매 달 연휴를 API를 호출하여 가져와 사용하는 방식에서, DB에서 연휴를 query하여 사용하는 방식으로 변경하였습니다. 매 달 첫 날 cronjob으로 API를 호출하여 다음 달 연휴를 DB에 저장합니다.

holiday_info라는 DB 테이블을 test 서버에 새로 추가하였습니다. 이후 test에 머지될 경우, main으로 머지하기 전, main 서버에도 DB 테이블을 추가해놓겠습니다!!