### PR TITLE
modify : 사서 로테이션 마감 일자 변경 (일요일 -> 금요일)

### DIFF
--- a/src/utils/rotation.calendar.js
+++ b/src/utils/rotation.calendar.js
@@ -19,7 +19,7 @@ export function getFourthWeekdaysOfMonth() {
   const fourthWeekStartDay = lastDateOfMonth - lastDayOfMonth - 6;
   const fourthWeekDays = [];
 
-  for (let i = 0; i < 7; i++) {
+  for (let i = 0; i < 5; i++) {
     const day = fourthWeekStartDay + i;
     if (day > 0 && day <= lastDateOfMonth) {
       fourthWeekDays.push(day);


### PR DESCRIPTION
사서 로테이션 마감 일자를 일요일에서 금요일로 이틀 앞당겼습니다.
이전에 마지막 주 일요일 바로 다음날이 새로운 달의 시작일이여서, 새로운 달의 시작일에 근무를 하는 사서가 자신의 근무를 확인하지 못하는 이슈가 있었는데, 
마지막 주 금요일 바로 다음날이 새로운 달의 시작일이라면, 주말 간 사서 일정을 확인할 수 있는 시간을 보장할 수 있습니다!